### PR TITLE
Make 'unity.path' configurationusable on any OS (including Windows)

### DIFF
--- a/unity-gradle-plugin/src/main/groovy/com/zasadnyy/gradle/unity/UnityPlugin.groovy
+++ b/unity-gradle-plugin/src/main/groovy/com/zasadnyy/gradle/unity/UnityPlugin.groovy
@@ -63,7 +63,7 @@ class UnityPlugin implements Plugin<Project> {
 
             def serializedBuildConfig = JsonOutput.toJson(configMap)
 
-            commandLine "${getUnityPath(project)}/Unity",
+            commandLine "${getUnityPath(project)}",
                     '-batchmode',
                     '-projectPath', "${project.rootDir.absolutePath}/${plugin.projectPath}",
                     '-logFile', buildConfig.logFile,


### PR DESCRIPTION
Removed behaviour that 'Unity' (as name of executable) is automatically added to 'unity.path', which does usually not work on Windows; 'unity.path' should now contain the full path including the executable itself
