### PR TITLE
Adjusted enums to Unity 5.3+

### DIFF
--- a/example-unity-project/Assets/GradleBuild/Editor/GradleBuildHelper.cs
+++ b/example-unity-project/Assets/GradleBuild/Editor/GradleBuildHelper.cs
@@ -43,7 +43,7 @@ namespace Com.Zasadnyy
 			case BuildTarget.Android:
 				ApplyAdroidConfig(config);
 				break;
-			case BuildTarget.iPhone:
+			case BuildTarget.iOS:
 				ApplyIosConfig(config);
 				break;
 			}
@@ -70,7 +70,7 @@ namespace Com.Zasadnyy
 			PlayerSettings.Android.useAPKExpansionFiles = config.Android.SplitApplicationBinary;
 
 			// TODO make configurable
-			EditorUserBuildSettings.androidBuildSubtarget = AndroidBuildSubtarget.ETC;
+			EditorUserBuildSettings.androidBuildSubtarget = MobileTextureSubtarget.ETC;
 		}
 
 		private static void ApplyIosConfig(BuildConfig config)
@@ -83,7 +83,7 @@ namespace Com.Zasadnyy
 
 		private static void PerformBuild(BuildConfig config)
 		{
-			if((config.TargetPlatform != BuildTarget.Android) && (config.TargetPlatform != BuildTarget.iPhone))
+			if((config.TargetPlatform != BuildTarget.Android) && (config.TargetPlatform != BuildTarget.iOS))
 			{
 				Debug.LogError("GradleBuildHelper error. Unsupported platform: " + config.TargetPlatform);
 				return;

--- a/unity-gradle-plugin/src/main/groovy/com/zasadnyy/gradle/unity/config/Platform.groovy
+++ b/unity-gradle-plugin/src/main/groovy/com/zasadnyy/gradle/unity/config/Platform.groovy
@@ -22,7 +22,7 @@ package com.zasadnyy.gradle.unity.config
  * by Unity Gradle plugin
  */
 enum Platform {
-    Android('Android'), Ios('iPhone')
+    Android('Android'), Ios('iOS')
 
     /**
      * For some platforms Unity has weird


### PR DESCRIPTION
http://docs.unity3d.com/530/Documentation/ScriptReference/BuildTarget-iPhone.html
was renamed to
http://docs.unity3d.com/530/Documentation/ScriptReference/BuildTarget.iOS.html

http://docs.unity3d.com/462/Documentation/ScriptReference/AndroidBuildSubtarget.html
was renamed to
http://docs.unity3d.com/530/Documentation/ScriptReference/MobileTextureSubtarget.html
